### PR TITLE
Improve logging

### DIFF
--- a/fusion_report/common/net.py
+++ b/fusion_report/common/net.py
@@ -82,14 +82,11 @@ class Net:
         return json.loads(token_response)['access_token']
 
     @staticmethod
-    def get_large_file(url: str, ignore_ssl: bool = False) -> None:
+    def get_large_file(url: str) -> None:
         """Method for downloading a large file."""
         try:
             headers = {'User-Agent': 'Mozilla/5.0'}
-            if ignore_ssl:
-                response = requests.get(url, headers=headers, stream=True, verify=False)
-            else:
-                response = requests.get(url, headers=headers, stream=True)
+            response = requests.get(url, headers=headers, stream=True)
 
             file = url.split('/')[-1].split('?')[0]
             Logger(__name__).info('Downloading %s', file)

--- a/fusion_report/common/net.py
+++ b/fusion_report/common/net.py
@@ -21,6 +21,8 @@ from fusion_report.data.fusiongdb import FusionGDB
 from fusion_report.data.fusiongdb2 import FusionGDB2
 from fusion_report.data.mitelman import MitelmanDB
 
+LOG = Logger(__name__)
+
 class Net:
 
     @staticmethod
@@ -89,7 +91,7 @@ class Net:
             response = requests.get(url, headers=headers, stream=True)
 
             file = url.split('/')[-1].split('?')[0]
-            Logger(__name__).info('Downloading %s', file)
+            LOG.info(f"Downloading {file}")
 
             if not os.path.exists(file) or \
                     (response.headers.get('Content-Length') or 0) != os.stat(file).st_size:
@@ -97,7 +99,8 @@ class Net:
                     for chunk in response.iter_content(chunk_size=8192):
                         if chunk:
                             out_file.write(chunk)
-        except requests.exceptions.RequestException as ex:
+        except Exception as ex:
+            LOG.error(f'Error downloading {file} from {url}, {ex}')
             raise DownloadException(ex)
 
     @staticmethod


### PR DESCRIPTION
This PR improves the logging in the `Net` module which is used to retrieve files. Hopefully this will provide some more details as to why the fusiondb files are not downloaded as expected. I was not able to reproduce the issue locally, the files seem to be downloaded as expected.

The entire module could use a refactoring, but lets keep it simple for now.


## Checklist

- [ ] Specify in detail the change
- [ ] Make sure to follow guidelines in `docs` when adding database/tool
- [ ] Documentation in `docs` is updated
- [ ] `CHANGELOG.md` is updated
- [ ] `README` is updated
